### PR TITLE
Escape more python keywords

### DIFF
--- a/src/utils/render.ts
+++ b/src/utils/render.ts
@@ -20,11 +20,50 @@ export function jsDocblock(docs: string[]): string {
   return `/**\n${lines.join("\n")}\n */\n`;
 }
 export function notPyKeyCase(name: string): string {
-  if (name == "global") {
-    return "global_";
-  }
-  if (name == "None") {
-    return "None_";
+  // Python keywords that need to be escaped
+  const pythonKeywords = new Set([
+    "False",
+    "None",
+    "True",
+    "and",
+    "as",
+    "assert",
+    "async",
+    "await",
+    "break",
+    "class",
+    "continue",
+    "def",
+    "del",
+    "elif",
+    "else",
+    "except",
+    "finally",
+    "for",
+    "from",
+    "global",
+    "if",
+    "import",
+    "in",
+    "is",
+    "lambda",
+    "nonlocal",
+    "not",
+    "or",
+    "pass",
+    "raise",
+    "return",
+    "try",
+    "while",
+    "with",
+    "yield",
+    "match",
+    "case",
+    "type",
+  ]);
+
+  if (pythonKeywords.has(name)) {
+    return name + "_";
   }
   return name;
 }


### PR DESCRIPTION
I got an IDL that has an ix account called `from`, the generated code looks like 
```
class BurnTokensAccounts(typing.TypedDict):
    glamState:SolPubkey
    glamSigner:SolPubkey
    glamMint:SolPubkey
    fromTokenAccount:SolPubkey
    from:SolPubkey
    token2022Program:SolPubkey
```

This is illegal syntax because `from` is a python keyword and it must be escaped