### PR TITLE
fix: use Bytes(n) instead of FixedSizeBytes(n, GreedyBytes) for fixed-size byte arrays

### DIFF
--- a/src/getTypeManifestVisitor.ts
+++ b/src/getTypeManifestVisitor.ts
@@ -351,10 +351,9 @@ export function getTypeManifestVisitor(input: {
                 visitFixedSizeType(node) {
                     const imports = new ImportMap();
                     if (node.type.kind == 'bytesTypeNode') {
-                        imports.add('..shared', 'FixedSizeBytes');
-                        imports.add('construct', 'GreedyBytes');
+                        imports.add('construct', 'Bytes');
                         return {
-                            borshType: fragment(`FixedSizeBytes(${node.size},GreedyBytes)`, imports), //`borsh.U8[${node.size}]`),
+                            borshType: fragment(`Bytes(${node.size})`, imports), //`borsh.U8[${node.size}]`),
                             fromDecode: fragment('{{name}}'),
                             fromJSON: fragment('bytes({{name}})'),
                             isEncodable: false,


### PR DESCRIPTION
fix: use `Bytes(n)` instead of `FixedSizeBytes(n, GreedyBytes)` for fixed-size byte arrays

The previous implementation incorrectly used `FixedSizeBytes` (Padded) with `GreedyBytes` as the subcon, which caused `GreedyBytes` to consume all remaining bytes instead of the specified fixed size.

For Rust `[u8; N]` types, the correct Python construct is `Bytes(N)`, which reads exactly N bytes as expected.

Fixes parsing errors where 'subcon parsed X bytes but was allowed only N'."