### PR TITLE
fix: PDA seed rendering (string seeds, pdaLinkNode resolution, valid pdas index)

### DIFF
--- a/public/templates/pages/pdasIndex.njk
+++ b/public/templates/pages/pdasIndex.njk
@@ -1,9 +1,36 @@
 {% extends "layout.njk" %}
 
 {% block main %}
-{% for pda in pdasToExport | sort(false, false, 'name') %}
-export * from './{{ pda.name | camelCase }}';
-{% else %}
-export default {};
+import typing
+
+from solders.pubkey import Pubkey as SolPubkey
+
+{% for program in programsToExport | sort(false, false, 'name') %}
+{% if program.pdas | length > 0 %}
+from ..program_id import {{ program.name | snakeCase | toUpperCase }}_PROGRAM_ADDRESS
+{% endif %}
+{% endfor %}
+
+{% for program in programsToExport | sort(false, false, 'name') %}
+{% for pda in program.pdas | sort(false, false, 'name') %}
+def find_{{ pda.name | snakeCase }}_pda({% for param in filterByField(pda.seeds, "name") %}{{ param.name }}: {{ getSeedType(param) }}{% if not loop.last %}, {% endif %}{% endfor %}) -> typing.Tuple[SolPubkey, int]:
+    seeds = [
+{% for seed in pda.seeds %}
+        {{ getSeed(seed) }},
+{% endfor %}
+    ]
+
+    address, bump = SolPubkey.find_program_address(seeds,
+    {% if pda.programId != null %}
+        SolPubkey.from_string('{{ pda.programId }}')
+    {% else %}
+        {{ program.name | snakeCase | toUpperCase }}_PROGRAM_ADDRESS
+    {% endif %}
+        )
+
+    return address, bump
+
+
+{% endfor %}
 {% endfor %}
 {% endblock %}

--- a/src/getRenderMapVisitor.ts
+++ b/src/getRenderMapVisitor.ts
@@ -378,6 +378,19 @@ export function getRenderMapVisitor(options: GetRenderMapOptions = {}) {
                           ...scope,
                           accounts: node.accounts,
                           argv: fields,
+                      }).map(account => {
+                          // Replace pdaLinkNode references with the full pdaNode they
+                          // point to, so the rendered find_* helper sees the seeds.
+                          const defaultValue = account.defaultValue;
+                          if (defaultValue?.kind !== 'pdaValueNode' || defaultValue.pda.kind !== 'pdaLinkNode') {
+                              return account;
+                          }
+                          const linkedPda = linkables.get([...instructionPath, defaultValue.pda]);
+                          if (!linkedPda) {
+                              logWarn(`Could not resolve PDA link "${defaultValue.pda.name}". Skipping its seeds.`);
+                              return account;
+                          }
+                          return { ...account, defaultValue: { ...defaultValue, pda: linkedPda } };
                       });
                       return createRenderMap(
                           `instructions/${camelCase(node.name)}.py`,

--- a/src/seeds.ts
+++ b/src/seeds.ts
@@ -1,4 +1,4 @@
-import { BytesValueNode, PdaSeedNode } from '@codama/nodes';
+import { BytesValueNode, PdaSeedNode, StringValueNode } from '@codama/nodes';
 
 import { hexToPyB } from './getTypeManifestVisitor';
 function parseUNumber(str: string): number {
@@ -9,6 +9,9 @@ function parseUNumber(str: string): number {
     }
     return parsed;
 }
+function pyBytesLiteral(value: string): string {
+    return `b"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
 export function getSeed(seed: PdaSeedNode): string {
     try {
         if (seed.kind === 'constantPdaSeedNode') {
@@ -16,10 +19,17 @@ export function getSeed(seed: PdaSeedNode): string {
                 const hexStr = hexToPyB((seed.value as BytesValueNode).data);
                 return `b"${hexStr}"`;
             }
+            if (seed.type.kind === 'stringTypeNode' && seed.type.encoding === 'utf8' && seed.value.kind === 'stringValueNode') {
+                return pyBytesLiteral((seed.value as StringValueNode).string);
+            }
+            console.warn(`Unsupported constant seed type: ${seed.type.kind}`);
             return '';
         } else if (seed.kind === 'variablePdaSeedNode') {
             if (seed.type.kind === 'publicKeyTypeNode') {
                 return `bytes(${seed.name})`;
+            }
+            if (seed.type.kind === 'stringTypeNode' && seed.type.encoding === 'utf8') {
+                return `${seed.name}.encode("utf-8")`;
             }
             if (seed.type.kind === 'numberTypeNode') {
                 const supportedFormats = ['u8', 'u16', 'u32', 'u64', 'u128'];

--- a/test/pdasIndex.test.ts
+++ b/test/pdasIndex.test.ts
@@ -1,0 +1,111 @@
+import {
+  constantPdaSeedNode,
+  instructionAccountNode,
+  instructionNode,
+  pdaLinkNode,
+  pdaNode,
+  pdaValueNode,
+  programNode,
+  publicKeyTypeNode,
+  rootNode,
+  stringTypeNode,
+  stringValueNode,
+  variablePdaSeedNode,
+} from "@codama/nodes";
+import { visit } from "@codama/visitors-core";
+import { test } from "vitest";
+
+import { getRenderMapVisitor } from "../src";
+import { renderMapContains, renderMapDoesNotContain } from "./_setup";
+
+const eventAuthorityPda = pdaNode({
+  name: "eventAuthority",
+  seeds: [
+    constantPdaSeedNode(
+      stringTypeNode("utf8"),
+      stringValueNode("event_authority"),
+    ),
+  ],
+});
+
+test("it renders a valid Python pdas index with constant string seeds", async () => {
+  const node = rootNode(
+    programNode({
+      name: "myProgram",
+      pdas: [eventAuthorityPda],
+      publicKey: "Test111111111111111111111111111111111111111",
+    }),
+  );
+
+  const renderMap = visit(node, getRenderMapVisitor());
+
+  await renderMapContains(renderMap, "pdas/index.py", [
+    "def find_event_authority_pda() -> typing.Tuple[SolPubkey, int]:",
+    'b"event_authority",',
+    "MY_PROGRAM_PROGRAM_ADDRESS",
+  ]);
+  await renderMapDoesNotContain(renderMap, "pdas/index.py", ["export * from"]);
+});
+
+test("it renders variable seeds as typed parameters in the pdas index", async () => {
+  const node = rootNode(
+    programNode({
+      name: "myProgram",
+      pdas: [
+        pdaNode({
+          name: "channel",
+          seeds: [
+            constantPdaSeedNode(
+              stringTypeNode("utf8"),
+              stringValueNode("channel"),
+            ),
+            variablePdaSeedNode("authority", publicKeyTypeNode()),
+            variablePdaSeedNode("namespace", stringTypeNode("utf8")),
+          ],
+        }),
+      ],
+      publicKey: "Test111111111111111111111111111111111111111",
+    }),
+  );
+
+  const renderMap = visit(node, getRenderMapVisitor());
+
+  await renderMapContains(renderMap, "pdas/index.py", [
+    "def find_channel_pda(authority: SolPubkey, namespace: str) -> typing.Tuple[SolPubkey, int]:",
+    'b"channel",',
+    "bytes(authority),",
+    'namespace.encode("utf-8"),',
+  ]);
+});
+
+test("it resolves pdaLinkNode defaults when rendering instruction PDA helpers", async () => {
+  const node = rootNode(
+    programNode({
+      instructions: [
+        instructionNode({
+          accounts: [
+            instructionAccountNode({
+              defaultValue: pdaValueNode(pdaLinkNode("eventAuthority")),
+              isSigner: false,
+              isWritable: false,
+              name: "eventAuthority",
+            }),
+          ],
+          name: "open",
+        }),
+      ],
+      name: "myProgram",
+      pdas: [eventAuthorityPda],
+      publicKey: "Test111111111111111111111111111111111111111",
+    }),
+  );
+
+  const renderMap = visit(node, getRenderMapVisitor());
+
+  // Without link resolution the seed list rendered empty, deriving the
+  // wrong address at runtime.
+  await renderMapContains(renderMap, "instructions/open.py", [
+    "def find_EventAuthority() -> typing.Tuple[SolPubkey, int]:",
+    'b"event_authority",',
+  ]);
+});


### PR DESCRIPTION
## Summary

Generating a client for a program that declares PDAs (tested with the Codama IDL of [solana-payment-channels](https://github.com/Moonsong-Labs/solana-payment-channels)) hits three related PDA bugs. Each gets its own commit:

1. **Constant string seeds are silently dropped.** `getSeed` only handled `bytesTypeNode` constants, so a seed like `"event_authority"` rendered as nothing and the generated `find_*` helper derived the wrong address from an empty seed list. Utf8 string constants now render as Python bytes literals, utf8 string variables as `name.encode("utf-8")`, and still-unsupported constant seed types warn instead of disappearing.

2. **`pdas/index.py` was not Python.** `pdasIndex.njk` still contained the TypeScript re-export form, so any program with a `pdaNode` produced a file that fails to parse:
   ```python
   export * from './eventAuthority';
   ```
   The template now renders a `find_<name>_pda` helper per program-level `pdaNode`, with variable seeds as typed parameters, reusing the same `getSeed` / `getSeedType` machinery as the instructions template.

3. **`pdaLinkNode` defaults resolved to empty seeds.** Instruction accounts defaulting to `pdaValueNode(pdaLinkNode(...))` rendered `find_*` helpers with `seeds = []`, because the template reads `defaultValue.pda.seeds` and a link node has none. The link is now resolved through the `LinkableDictionary` that the visitor already records.

## Verification

- `pnpm test`: 35 passed (32 existing + 3 new regression tests in `test/pdasIndex.test.ts`).
- Regenerated the payment-channels client end to end: every generated file passes `py_compile`, and both `find_event_authority_pda` (pdas index) and the instruction-level `find_EventAuthority` now derive the same address as a hand-written `Pubkey.find_program_address([b"event_authority"], PROGRAM_ID)`.
- `eslint` on the touched files: 0 errors.

## Note

`pnpm build` currently emits a `dist/index.node.cjs` / `.mjs` with a syntax error on `main` as well (the file tail is duplicated), which also makes `pnpm lint` and `e2e/test.sh` fail before this change. That looks unrelated to the renderer, so it is not addressed here; happy to file it separately.
