### PR TITLE
 Support optional instruction accounts

### DIFF
--- a/public/templates/pages/instructionsPage.njk
+++ b/public/templates/pages/instructionsPage.njk
@@ -21,7 +21,11 @@ layout = borsh.CStruct(
 class {{instructionName | pascalCase}}Accounts(typing.TypedDict):
 {% if accounts.length > 0 %}
 {% for acc in accounts %}
+{% if acc.isOptional %}
+    {{acc.name | notKeywordCase}}: typing.Optional[SolPubkey]
+{% else %}
     {{acc.name | notKeywordCase}}:SolPubkey
+{% endif %}
 {% endfor %}
 {% else %}
     pass
@@ -37,9 +41,17 @@ def {{instructionName | pascalCase}}(
 ) ->Instruction:
     keys: list[AccountMeta] = [
 {% for acc in accounts %}
+{% if not acc.isOptional %}
     AccountMeta(pubkey=accounts["{{acc.name | notKeywordCase }}"], is_signer={{ 'True' if acc.isSigner else 'False' }}, is_writable={{ 'True' if acc.isWritable else 'False' }}),
+{% endif %}
 {% endfor %}
     ]
+{% for acc in accounts %}
+{% if acc.isOptional %}
+    if accounts.get("{{acc.name | notKeywordCase }}") is not None:
+        keys.append(AccountMeta(pubkey=accounts["{{acc.name | notKeywordCase }}"], is_signer={{ 'True' if acc.isSigner else 'False' }}, is_writable={{ 'True' if acc.isWritable else 'False' }}))
+{% endif %}
+{% endfor %}
     if remaining_accounts is not None:
         keys += remaining_accounts
 {%if discriminators.length>1 %}


### PR DESCRIPTION
 The renderer ignored the isOptional flag on instruction accounts — every account became a required TypedDict field and was always pushed to keys, so an optional account couldn't be omitted.

  Now optional accounts are typed typing.Optional[SolPubkey] and appended only when provided:
  
  MyInstruction({...})                       # omitted → account not sent
  MyInstruction({..., "optionalAccount": pk})  # provided → account appended

